### PR TITLE
Fix scratch image file name mismatches

### DIFF
--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -704,7 +704,7 @@ def get_t1w_preproc_images(import_path,
         run.command('mrconvert '
                     + preproc_image_path
                     + ' '
-                    + path.to_scratch('T1_masked.mif' \
+                    + path.to_scratch('T1_premasked.mif' \
                                       if preproc_image_is_masked \
                                       else 'T1.mif'))
 
@@ -1957,7 +1957,7 @@ def run_participant(bids_dir, session, shared,
                        os.path.join('tractogram',
                                     session_label
                                     + '_space-dwi_tdi.nii.gz'))
-        output_items['tdi_t1.mif'] = \
+        output_items['tdi_T1.mif'] = \
             OutputItem(True, 3, False, '-strides +1,+2,+3',
                        os.path.join('tractogram',
                                     session_label


### PR DESCRIPTION
Closes #100.

Two errors identified by @treanus:
- Mismatch in file name between imported premasked T1-weighted image and attempts to load that image.
- Mismatch in file name between generated TDI on T1-weighted image grid and attempted export of that image upon participant-level analysis completion.